### PR TITLE
Fix for count(): Parameter must be an array or an object that impleme…

### DIFF
--- a/src/Horizon/Exception/HorizonException.php
+++ b/src/Horizon/Exception/HorizonException.php
@@ -142,7 +142,7 @@ class HorizonException extends \ErrorException
         if ($this->transactionResultCode) {
             $message .= sprintf(" Tx Result: %s", $this->transactionResultCode);
         }
-        if (count($this->operationResultCodes) > 0) {
+        if (!empty($this->operationResultCodes)) {
             $message .= sprintf(" Op Results: %s", print_r($this->operationResultCodes,true));
         }
 


### PR DESCRIPTION
When submitting a transaction an Exception gets fired with:
`Fix for count(): Parameter must be an array or an object that implements Countable`

This is a minor fix for that issue.