### PR TITLE
Allow access to guzzle client

### DIFF
--- a/src/Horizon/ApiClient.php
+++ b/src/Horizon/ApiClient.php
@@ -35,7 +35,7 @@ class ApiClient
     /**
      * @var Client
      */
-    private $httpClient;
+    public $httpClient;
 
     /**
      * @var string


### PR DESCRIPTION
Access to the guzzle client instance is quite useful, it allows for easy response mocking and logging using guzzle handler stack.

Currently requires stuff like this given the property is private:

```php
<?php

namespace Tests\Unit\Stellar;

use GuzzleHttp\Client;
use GuzzleHttp\Handler\MockHandler;
use ZuluCrypto\StellarSdk\Horizon\ApiClient;

class MockApiClient extends ApiClient
{
    public static function newMockTestnetClient(MockHandler $handler)
    {
        $apiClient = self::newTestnetClient();

        $reflection = new \ReflectionClass($apiClient);
        $reflection_property = $reflection->getProperty('httpClient');
        $reflection_property->setAccessible(true);

        $reflection_property->setValue($apiClient, new Client([
            'base_uri' => 'https://horizon-testnet.stellar.org/',
            'handler' => $handler,
        ]));

        return $apiClient;
    }
}
```

`protected` would also make this easier, though `public` would avoid the need to extend anything.