### PR TITLE
Fixed parsing result_xdr error

### DIFF
--- a/src/Horizon/Api/PostTransactionResponse.php
+++ b/src/Horizon/Api/PostTransactionResponse.php
@@ -43,6 +43,9 @@ class PostTransactionResponse extends HorizonResponse
         if (!empty($rawData['result_xdr'])) {
             $xdr = new XdrBuffer(base64_decode($rawData['result_xdr']));
             $this->result = TransactionResult::fromXdr($xdr);
+        }  else if (!empty($rawData['extras']['result_xdr'])) {
+            $xdr = new XdrBuffer(base64_decode($rawData['extras']['result_xdr']));
+            $this->result = TransactionResult::fromXdr($xdr);
         }
     }
 


### PR DESCRIPTION
When transfering a custom asset to an account which not trust this custom asset, the result could be NULL.